### PR TITLE
Scale Instance Difficulty with Minimap

### DIFF
--- a/Modules/Appearance.lua
+++ b/Modules/Appearance.lua
@@ -238,6 +238,10 @@ function Appearance:SetScale(value)
 		QuestWatchFrame:GetSize()
 	else
 		ObjectiveTrackerFrame:GetSize()
+	-- Fix Instance Difficulty size --
+		MiniMapInstanceDifficulty:SetScale(value)
+		GuildInstanceDifficulty:SetScale(value)
+		MiniMapChallengeMode:SetScale(value)
 	end
 end
 


### PR DESCRIPTION
https://github.com/Ravendwyr/Chinchilla/issues/62 seems to be partial bug, partial enhancement.

This PR is to address the bug portion.  That is: All other Minimap icons scale with Minimap when using Appearance module's scale.  Instance difficulty was not scaling - in the case of button attached to Minimap, button would stray.  Setting scale keeps that from happening.

In order to reproduce/test: Enter and Raid and change Appearance - size.